### PR TITLE
chore: notify to rocketchat_talk_webhook

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -181,7 +181,7 @@ def notification(config):
         "image": "plugins/slack",
         "settings": {
             "webhook": {
-                "from_secret": "rocketchat_chat_webhook",
+                "from_secret": "rocketchat_talk_webhook",
             },
             "channel": "builds",
         },


### PR DESCRIPTION
Should fix the fail of notification in the merge CI

https://drone.owncloud.com/owncloud-ci/wait-for/364/6/1

```
latest: Pulling from plugins/slack
Digest: sha256:dcc6e41ba1c052129631942815b352cdaef5a069a87ad232ff2c1962293b0067
Status: Downloaded newer image for plugins/slack:latest
2024/06/10 06:28:52 failed to post webhook: Post "******": dial tcp: lookup chat.owncloud.com on 127.0.0.11:53: no such host
```
