### PR TITLE
chore: bump golang to 1.22

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -324,7 +324,7 @@ def binaryReleases(ctx, binaryTargets):
 def binaryReleaseStep(ctx, os, arch):
     return {
         "name": "binaries-%s-%s" % (os, arch),
-        "image": "owncloudci/golang:1.19",
+        "image": "owncloudci/golang:1.22",
         "pull": "always",
         "commands": [
             "GOOS=%s GOARCH=%s CGO_ENABLED=0 go build -o bin/wait-for-%s-%s ." % (os, arch, os, arch),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/owncloud-ci/wait-for
 
-go 1.19
+go 1.22


### PR DESCRIPTION
This should get past the CVEs reported by Trivy in:
https://github.com/owncloud-docker/ubuntu/pull/182