### PR TITLE
chore(deps): add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Adds `github-actions` ecosystem to `.github/dependabot.yml` so Dependabot tracks updates for pinned Actions in the workflow (`actions/checkout`, `actions/setup-go`, `softprops/action-gh-release`)

## Test plan

- [ ] Verify Dependabot picks up the GitHub Actions entries after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)