### PR TITLE
chore(deps): update Go to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/owncloud-ci/wait-for
 
-go 1.25.8
+go 1.26.3

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 ARG TARGETARCH
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Updates `go.mod` from Go 1.25.8 to 1.26.3 (latest stable release)
- Pins `latest/Dockerfile` builder image tag to `golang:1.26.3-alpine` (digest unchanged)
- `go.sum` unchanged — project has no external dependencies

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Docker build succeeds (`docker build -f latest/Dockerfile`)
- [x] Smoke test passes (`wait-for -help` exits 0)